### PR TITLE
Add type declarations file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,15 @@
+declare class Cyclist<T> {
+  readonly size: number
+  readonly mask: number
+  readonly values: (T | undefined)[]
+  constructor(size: number)
+  put(index: number, val: T): number
+  get(index: number): T | undefined
+  del(index: number): T | undefined
+}
+interface CyclistConstructor {
+  new <T>(size: number): Cyclist<T>
+  <T>(size: number): Cyclist<T>
+}
+declare const _default: CyclistConstructor
+export = _default

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/mafintosh/cyclist",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "standard && brittle test.js"
   },


### PR DESCRIPTION
The lack of a declarations file makes it very difficult to use this lib in Typescript.

This PR adds a declaration file.

This enables to use it in TypeScript either this way:

```typescript
import cyclist from 'cyclist';

const list = cyclist(4);

list.put(42, 'hello 42'); // store something and index 42
list.put(43, 'hello 43'); // store something and index 43

console.log(list.get(42)); // prints hello 42
console.log(list.get(46)); // prints hello 42 again since 46 - 42 == list.size
```

or this way:

```typescript
import Cyclist from 'cyclist';

const list = new Cyclist(4);

list.put(42, 'hello 42'); // store something and index 42
list.put(43, 'hello 43'); // store something and index 43

console.log(list.get(42)); // prints hello 42
console.log(list.get(46)); // prints hello 42 again since 46 - 42 == list.size
```

I also added a type parameter to have a predictable type when getting values:

```typescript
import Cyclist from 'cyclist';

const list = new Cyclist<string>(4);

list.put(42, 'hello'); // store something and index 42

const value/*: string | undefined*/ = list.get(46); // retrieve something from index 42
```